### PR TITLE
Upgrade Astro 4 → 5 and modernize all dependencies

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,7 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { defineConfig, squooshImageService } from 'astro/config';
+import { defineConfig, sharpImageService } from 'astro/config';
 
 import sitemap from '@astrojs/sitemap';
 import tailwind from '@astrojs/tailwind';
@@ -63,7 +63,7 @@ export default defineConfig({
   ],
 
   image: {
-    service: squooshImageService(),
+    service: sharpImageService(),
   },
 
   markdown: {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",
-    "@astrolib/analytics": "^0.5.0",
+    "@astrolib/analytics": "^0.6.1",
     "@astrolib/seo": "^1.0.0-beta.8",
     "astro": "^5.18.2",
     "astro-google-fonts-optimizer": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restorativebodyworkatxcom",
   "description": "Website for restorativebodyworkatxcom",
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "private": true,
   "scripts": {
     "dev": "astro dev",
@@ -13,42 +13,42 @@
     "lint:eslint": "eslint . --ext .js,.ts,.astro"
   },
   "dependencies": {
-    "@astrojs/rss": "^4.0.1",
-    "@astrojs/sitemap": "^3.0.4",
+    "@astrojs/rss": "^4.0.18",
+    "@astrojs/sitemap": "^3.7.3",
     "@astrolib/analytics": "^0.5.0",
-    "@astrolib/seo": "^1.0.0-beta.5",
-    "astro": "^4.1.1",
+    "@astrolib/seo": "^1.0.0-beta.8",
+    "astro": "^5.18.2",
     "astro-google-fonts-optimizer": "^0.2.2",
-    "astro-icon": "^1.0.2",
+    "astro-icon": "^1.1.5",
     "html-escaper": "^3.0.3",
-    "limax": "4.1.0",
+    "limax": "^4.2.3",
     "lodash.merge": "^4.6.2",
-    "typescript-esbuild": "^0.3.5",
-    "unpic": "^3.16.0"
+    "unpic": "^3.22.0"
   },
   "devDependencies": {
-    "@astrojs/mdx": "^2.0.3",
-    "@astrojs/partytown": "^2.0.3",
-    "@astrojs/tailwind": "5.1.0",
+    "@astrojs/mdx": "^4.3.14",
+    "@astrojs/partytown": "^2.1.7",
+    "@astrojs/tailwind": "^6.0.2",
     "@iconify-json/flat-color-icons": "^1.1.10",
     "@iconify-json/tabler": "^1.1.103",
     "@tailwindcss/typography": "^0.5.10",
     "@types/lodash.merge": "^4.6.9",
-    "@typescript-eslint/eslint-plugin": "^6.18.0",
-    "@typescript-eslint/parser": "^6.18.0",
-    "eslint": "^8.56.0",
-    "eslint-plugin-astro": "^0.31.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-astro": "^1.0.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "js-yaml": "^4.1.0",
     "mdast-util-to-string": "^4.0.0",
-    "prettier": "^3.1.1",
-    "prettier-plugin-astro": "^0.12.3",
+    "prettier": "^3.5.0",
+    "prettier-plugin-astro": "^0.14.0",
     "reading-time": "^1.5.0",
-    "tailwind-merge": "^2.2.0",
+    "tailwind-merge": "^2.5.0",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.7.0"
   },
   "engines": {
-    "node": ">=18.14.1"
-  }
+    "node": ">=18.17.1"
+  },
+  "type": "module"
 }


### PR DESCRIPTION
- astro 4.1.1 → 5.18.2
- @astrojs/mdx 2 → 4.3.14
- @astrojs/tailwind 5.1.0 → 6.0.2
- @astrojs/sitemap 3.0.4 → 3.7.3
- @astrojs/partytown 2.0.3 → 2.1.7
- @astrojs/rss 4.0.1 → 4.0.18
- astro-icon 1.0.2 → 1.1.5
- @astrolib/seo 1.0.0-beta.5 → 1.0.0-beta.8
- limax 4.1.0 → 4.2.3
- typescript 5.3.3 → 5.7
- prettier 3.1.1 → 3.5
- eslint-plugin-astro 0.31 → 1.0
- @typescript-eslint/* 6 → 7
- Remove deprecated typescript-esbuild package
- Replace squooshImageService with sharpImageService (squoosh removed in Astro 5)
- Add "type": "module" to eliminate Node.js ES module warning

https://claude.ai/code/session_01Lg6wCjqVcP6sQRadUN2gT7